### PR TITLE
Create a v1.40 client for the device-requests test

### DIFF
--- a/tests/unit/api_container_test.py
+++ b/tests/unit/api_container_test.py
@@ -5,6 +5,7 @@ import json
 import signal
 
 import docker
+from docker.api import APIClient
 import pytest
 import six
 
@@ -12,7 +13,7 @@ from . import fake_api
 from ..helpers import requires_api_version
 from .api_test import (
     BaseAPIClientTest, url_prefix, fake_request, DEFAULT_TIMEOUT_SECONDS,
-    fake_inspect_container
+    fake_inspect_container, url_base
 )
 
 try:
@@ -767,10 +768,14 @@ class CreateContainerTest(BaseAPIClientTest):
         assert args[1]['headers'] == {'Content-Type': 'application/json'}
         assert args[1]['timeout'] == DEFAULT_TIMEOUT_SECONDS
 
-    @requires_api_version('1.40')
     def test_create_container_with_device_requests(self):
-        self.client.create_container(
-            'busybox', 'true', host_config=self.client.create_host_config(
+        client = APIClient(version='1.40')
+        fake_api.fake_responses.setdefault(
+            '{0}/v1.40/containers/create'.format(fake_api.prefix),
+            fake_api.post_fake_create_container,
+        )
+        client.create_container(
+            'busybox', 'true', host_config=client.create_host_config(
                 device_requests=[
                     {
                         'device_ids': [
@@ -793,9 +798,9 @@ class CreateContainerTest(BaseAPIClientTest):
         )
 
         args = fake_request.call_args
-        assert args[0][1] == url_prefix + 'containers/create'
+        assert args[0][1] == url_base + 'v1.40/' + 'containers/create'
         expected_payload = self.base_create_payload()
-        expected_payload['HostConfig'] = self.client.create_host_config()
+        expected_payload['HostConfig'] = client.create_host_config()
         expected_payload['HostConfig']['DeviceRequests'] = [
             {
                 'Driver': '',
@@ -820,7 +825,8 @@ class CreateContainerTest(BaseAPIClientTest):
             }
         ]
         assert json.loads(args[1]['data']) == expected_payload
-        assert args[1]['headers'] == {'Content-Type': 'application/json'}
+        assert args[1]['headers']['Content-Type'] == 'application/json'
+        assert set(args[1]['headers']) <= {'Content-Type', 'User-Agent'}
         assert args[1]['timeout'] == DEFAULT_TIMEOUT_SECONDS
 
     def test_create_container_with_labels_dict(self):


### PR DESCRIPTION
Fixes the test in CI for docker/docker-py#2471 theoretically

Unfortunately, looks like `User-Agent` needs to be allowed in the request headers. Not sure why, possibly a requirement of the v1.40 API, but it could be that I'm not setting up the environment correctly